### PR TITLE
Move all logic in LogicManager to model

### DIFF
--- a/src/main/java/trackitnus/logic/LogicManager.java
+++ b/src/main/java/trackitnus/logic/LogicManager.java
@@ -3,7 +3,6 @@ package trackitnus.logic;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.LocalDate;
-import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -19,7 +18,6 @@ import trackitnus.model.ReadOnlyTrackIter;
 import trackitnus.model.commons.Code;
 import trackitnus.model.contact.Contact;
 import trackitnus.model.lesson.Lesson;
-import trackitnus.model.lesson.LessonWeekday;
 import trackitnus.model.module.Module;
 import trackitnus.model.task.Task;
 import trackitnus.storage.Storage;
@@ -92,46 +90,36 @@ public class LogicManager implements Logic {
     // All functions should only generate new predicates and use the corresponding getFilteredList to return
     @Override
     public ObservableList<Lesson> getUpcomingLessons() {
-        model.sortLesson();
-        model.updateFilteredLessonList(Model.PREDICATE_SHOW_ALL_LESSONS);
-        return model.getFilteredLessonList();
+        return model.getUpcomingLessons();
     }
 
     @Override
     public ObservableList<Lesson> getDayUpcomingLessons(LocalDate date) {
-        LessonWeekday weekday = LessonWeekday.getLessonWeekDay(date);
-        Predicate<Lesson> predicate = lesson -> (lesson.getWeekday().equals(weekday));
-        ObservableList<Lesson> allUpcomingLessons = getUpcomingLessons();
-        return allUpcomingLessons.filtered(predicate);
+        return model.getDayUpcomingLessons(date);
     }
 
     @Override
     public ObservableList<Lesson> getModuleLessons(Code code) {
-        Predicate<Lesson> predicate = lesson -> (lesson.getCode().equals(code));
-        model.updateFilteredLessonList(predicate);
-        return model.getFilteredLessonList();
+        return model.getModuleLessons(code);
     }
 
     @Override
     public ObservableList<Task> getModuleTasks(Code code) {
-        Predicate<Task> p = task -> task.belongsToModule(code);
-        model.updateFilteredTaskList(p);
-        return model.getFilteredTaskList();
+        return model.getModuleTasks(code);
     }
 
     @Override
     public ObservableList<Task> getUpcomingTasks() {
-        model.updateFilteredTaskList(Model.PREDICATE_SHOW_ALL_TASKS);
-        return model.getFilteredTaskList();
+        return model.getUpcomingTasks();
     }
 
     @Override
     public ObservableList<Task> getDayUpcomingTasks(LocalDate date) {
-        Predicate<Task> p = task -> task.getDate().equals(date);
-        return model.getFilteredTaskList().filtered(p);
+        return model.getDayUpcomingTasks(date);
     }
 
     //--------------------------------END of V1.3's new functions--------------------------------
+
     @Override
     public Path getTrackIterFilePath() {
         return model.getTrackIterFilePath();

--- a/src/main/java/trackitnus/model/Model.java
+++ b/src/main/java/trackitnus/model/Model.java
@@ -257,13 +257,13 @@ public interface Model {
     ObservableList<Task> getModuleTasks(Code code);
 
     /**
-     * @return the list of all tasks that take place on and after the current day
+     * @return the list of all tasks
      */
     ObservableList<Task> getUpcomingTasks();
 
     /**
      * @param date The date to query
-     * @return the list of all tasks that take place on that specific day
+     * @return the list of all tasks that take place on the specified date
      */
     ObservableList<Task> getDayUpcomingTasks(LocalDate date);
 

--- a/src/main/java/trackitnus/model/Model.java
+++ b/src/main/java/trackitnus/model/Model.java
@@ -1,6 +1,7 @@
 package trackitnus.model;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -229,6 +230,44 @@ public interface Model {
      * Returns an unmodifiable view of the filtered lesson list
      */
     ObservableList<Lesson> getFilteredLessonList();
+
+    //--------------------------------START of V1.3's new functions--------------------------------
+
+    /**
+     * @return the list of all lessons that will take place on and up to a week after the current day
+     */
+    ObservableList<Lesson> getUpcomingLessons();
+
+    /**
+     * @param date The date to query
+     * @return all lessons happens on that date
+     */
+    ObservableList<Lesson> getDayUpcomingLessons(LocalDate date);
+
+    /**
+     * @param code The module code to query
+     * @return the list of lesson for a specific module
+     */
+    ObservableList<Lesson> getModuleLessons(Code code);
+
+    /**
+     * @param code The module code to query
+     * @return the list of task for a specific module
+     */
+    ObservableList<Task> getModuleTasks(Code code);
+
+    /**
+     * @return the list of all tasks that take place on and after the current day
+     */
+    ObservableList<Task> getUpcomingTasks();
+
+    /**
+     * @param date The date to query
+     * @return the list of all tasks that take place on that specific day
+     */
+    ObservableList<Task> getDayUpcomingTasks(LocalDate date);
+
+    //--------------------------------END of V1.3's new functions--------------------------------
 
     /**
      * Updates the filter of the filtered lesson list to filter by the given {@code predicate}.

--- a/src/main/java/trackitnus/model/ModelManager.java
+++ b/src/main/java/trackitnus/model/ModelManager.java
@@ -3,6 +3,7 @@ package trackitnus.model;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -19,6 +20,7 @@ import trackitnus.logic.commands.exceptions.CommandException;
 import trackitnus.model.commons.Code;
 import trackitnus.model.contact.Contact;
 import trackitnus.model.lesson.Lesson;
+import trackitnus.model.lesson.LessonWeekday;
 import trackitnus.model.lesson.Type;
 import trackitnus.model.module.Module;
 import trackitnus.model.task.Task;
@@ -281,6 +283,50 @@ public class ModelManager implements Model {
     @Override
     public ObservableList<Lesson> getFilteredLessonList() {
         return filteredLessons;
+    }
+
+    //--------------------------------START of V1.3's new functions--------------------------------
+    // TODO:
+    // All the current functions are just dummy implementations
+    // All functions should only generate new predicates and use the corresponding getFilteredList to return
+    @Override
+    public ObservableList<Lesson> getUpcomingLessons() {
+        sortLesson();
+        updateFilteredLessonList(PREDICATE_SHOW_ALL_LESSONS);
+        return getFilteredLessonList();
+    }
+
+    @Override
+    public ObservableList<Lesson> getDayUpcomingLessons(LocalDate date) {
+        LessonWeekday weekday = LessonWeekday.getLessonWeekDay(date);
+        Predicate<Lesson> predicate = lesson -> (lesson.getWeekday().equals(weekday));
+        return getUpcomingLessons().filtered(predicate);
+    }
+
+    @Override
+    public ObservableList<Lesson> getModuleLessons(Code code) {
+        Predicate<Lesson> predicate = lesson -> (lesson.getCode().equals(code));
+        updateFilteredLessonList(predicate);
+        return getFilteredLessonList();
+    }
+
+    @Override
+    public ObservableList<Task> getModuleTasks(Code code) {
+        Predicate<Task> p = task -> task.belongsToModule(code);
+        updateFilteredTaskList(p);
+        return getFilteredTaskList();
+    }
+
+    @Override
+    public ObservableList<Task> getUpcomingTasks() {
+        updateFilteredTaskList(Model.PREDICATE_SHOW_ALL_TASKS);
+        return getFilteredTaskList();
+    }
+
+    @Override
+    public ObservableList<Task> getDayUpcomingTasks(LocalDate date) {
+        Predicate<Task> p = task -> task.getDate().equals(date);
+        return getFilteredTaskList().filtered(p);
     }
 
     @Override

--- a/src/test/java/trackitnus/testutil/ModelStub.java
+++ b/src/test/java/trackitnus/testutil/ModelStub.java
@@ -1,6 +1,7 @@
 package trackitnus.testutil;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -178,6 +179,36 @@ public class ModelStub implements Model {
 
     @Override
     public ObservableList<Lesson> getFilteredLessonList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Lesson> getUpcomingLessons() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Lesson> getDayUpcomingLessons(LocalDate date) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Lesson> getModuleLessons(Code code) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Task> getModuleTasks(Code code) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Task> getUpcomingTasks() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Task> getDayUpcomingTasks(LocalDate date) {
         throw new AssertionError("This method should not be called.");
     }
 


### PR DESCRIPTION
The reason behind this is that Logic should only act as a compatibility layer. By moving all the logic to Model, future new functions can use those methods in a downward fashion (all logic calls go to Model) instead of calling upwards (low level classes call high-level Logic interface). Also, it will make Logic to have a single responsibility only: act as a compatibility layer between the front-end and the back-end