### PR TITLE
fix occasional empty task and lesson lists in upcoming tab

### DIFF
--- a/src/main/java/trackitnus/ui/MainWindow.java
+++ b/src/main/java/trackitnus/ui/MainWindow.java
@@ -170,7 +170,7 @@ public class MainWindow extends UiPart<Stage> {
 
         switch (tabName) {
         case UpcomingPanel.TYPE:
-            tabPanelPlaceholder.getChildren().add(upcomingPanel.getRoot());
+            tabPanelPlaceholder.getChildren().add(new UpcomingPanel(logic).getRoot());
             moduleTabInContext = "";
             break;
         case Module.TYPE:


### PR DESCRIPTION
when upcoming tab is pressed after a module tab, it does not display any
task and lesson occasionally, and will only populate once user scrolls.
Fix it by declaring a new upcoming panel when tab is called.